### PR TITLE
Fix assert condition and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,17 @@ The final value yielded by `parse` will be the same as if you had called `JSON.p
 The built-in JSON.parse is faster (~10x in simple benchmarking) if you don't need streaming.
 
 [stream-json](https://www.npmjs.com/package/stream-json), is larger, more complex, and a bit slower (~2-3x slower in simple benchmarking), but it's much more featureful, and if you only need a subset of the data it can likely be much faster.
+
+## Development
+
+Install dependencies with:
+
+```bash
+npm ci
+```
+
+Run the test suite with:
+
+```bash
+npm test
+```

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -130,7 +130,7 @@ export async function assertSameAsJsonParse(
       actual.success,
       `Expected ${name} to succeed but it failed with ${(expectedError as Error)?.stack}`,
     );
-  } else if ((shouldSucceed = false)) {
+  } else if (shouldSucceed === false) {
     assert.ok(!actual.success, `Expected ${name} to fail`);
   }
 }


### PR DESCRIPTION
## Summary
- correct boolean check in `assertSameAsJsonParse`
- document how to install deps and run tests

## Testing
- `npm ci` *(fails: EHOSTUNREACH)*
- `npm test` *(fails: wireit not found)*