### PR TITLE
Fix comment about buffer completion

### DIFF
--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -589,7 +589,7 @@ interface ObjectEndToken {
  */
 class Input {
   buffer = '';
-  // True if the no more content will be added to the buffer.
+  // True if no more content will be added to the buffer.
   bufferComplete = false;
   moreContentExpected = true;
   #stream: AsyncIterator<string>;


### PR DESCRIPTION
## Summary
- correct typo in `Input` class comment for `bufferComplete`

## Testing
- `npm ci` *(fails: Exit handler never called)*
- `npm test` *(fails: wireit not found)*