### PR TITLE
Add chunked number tests

### DIFF
--- a/src/test/tokenize_test.ts
+++ b/src/test/tokenize_test.ts
@@ -113,4 +113,16 @@ suite('tokenizeJsonStream', () => {
       {type: JsonTokenType.Number, value: 123},
     ]);
   });
+  test('can tokenize a number split across chunks', async () => {
+    const tokens = tokenize(makeStream('1', '23'));
+    assert.deepEqual(await toFlatArray(tokens), [
+      {type: JsonTokenType.Number, value: 123},
+    ]);
+  });
+  test('can tokenize a decimal number split across chunks', async () => {
+    const tokens = tokenize(makeStream('3.', '14'));
+    assert.deepEqual(await toFlatArray(tokens), [
+      {type: JsonTokenType.Number, value: 3.14},
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- add tests for tokenizing numbers split across chunks

## Testing
- `npm test` *(fails: `wireit` not found)*