### PR TITLE
Improve test error messages

### DIFF
--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -25,7 +25,7 @@ async function* mapStructuralClone<T>(
 }
 
 suite('parse', () => {
-  test('round tripping', async () => {
+  test('round tripping', async (t) => {
     const jsonValues = [
       {
         a: [{b: ''}],
@@ -89,8 +89,10 @@ suite('parse', () => {
         },
       },
     ] as const;
-    for (const jsonValue of jsonValues) {
-      await assertRoundTrips(jsonValue);
+    for (const [i, jsonValue] of jsonValues.entries()) {
+      await t.test(`case ${i}`, async () => {
+        await assertRoundTrips(jsonValue);
+      });
     }
   });
 
@@ -100,14 +102,15 @@ suite('parse', () => {
     // a string literal directly, and when decoded using a u escape.
     for (let i = 0; i <= 0xffff; i++) {
       const charcodeStr = String.fromCharCode(i);
+      const hex = i.toString(16).padStart(4, '0');
       await assertSameAsJsonParse(
-        `string literal with ${i}th character`,
+        `literal U+${hex}`,
         `"${charcodeStr}"`,
         undefined,
       );
       await assertSameAsJsonParse(
-        `\\u escape with ${i}th character`,
-        `"\\u${i.toString(16).padStart(4, '0')}"`,
+        `\\u escape U+${hex}`,
+        `"\\u${hex}"`,
         undefined,
       );
     }
@@ -121,8 +124,8 @@ suite('parse', () => {
     )
       .trim()
       .split('\n');
-    for (const str of jsonVals) {
-      await assertSameAsJsonParse(str, str, true);
+    for (const [i, str] of jsonVals.entries()) {
+      await assertSameAsJsonParse(`value ${i}`, str, true);
     }
   });
 

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -121,16 +121,19 @@ export async function assertSameAsJsonParse(
   assert.deepEqual(
     actual,
     expected,
-    `${name} parsing \"${json}\"\nActualError: ${(actualError as Error)?.stack}\nExpectedError: ${
+    `${name} parsing ${JSON.stringify(json)}"\nActualError: ${(actualError as Error)?.stack}\nExpectedError: ${
       (expectedError as Error)?.stack
     }`,
   );
   if (shouldSucceed === true) {
     assert.ok(
       actual.success,
-      `${name} expected success for \"${json}\" but failed with ${(expectedError as Error)?.stack}`,
+      `${name} expected success for ${JSON.stringify(json)} but failed with ${(expectedError as Error)?.stack}`,
     );
   } else if (shouldSucceed === false) {
-    assert.ok(!actual.success, `${name} expected failure for \"${json}\"`);
+    assert.ok(
+      !actual.success,
+      `${name} expected failure for ${JSON.stringify(json)}`,
+    );
   }
 }

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -121,16 +121,16 @@ export async function assertSameAsJsonParse(
   assert.deepEqual(
     actual,
     expected,
-    `ActualError: ${(actualError as Error)?.stack} ExpectedError: ${
+    `${name} parsing \"${json}\"\nActualError: ${(actualError as Error)?.stack}\nExpectedError: ${
       (expectedError as Error)?.stack
     }`,
   );
   if (shouldSucceed === true) {
     assert.ok(
       actual.success,
-      `Expected ${name} to succeed but it failed with ${(expectedError as Error)?.stack}`,
+      `${name} expected success for \"${json}\" but failed with ${(expectedError as Error)?.stack}`,
     );
-  } else if ((shouldSucceed = false)) {
-    assert.ok(!actual.success, `Expected ${name} to fail`);
+  } else if (shouldSucceed === false) {
+    assert.ok(!actual.success, `${name} expected failure for \"${json}\"`);
   }
 }


### PR DESCRIPTION
## Summary
- clarify assertions so test failures are easier to understand
- print input name and value in assertion messages
- show index for parameterized tests

## Testing
- `npx tsc` *(fails: Cannot find type definition file for 'babel__generator' and others)*