### PR TITLE
feat: Add GitHub Action to run node benchmark and comment on PRs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,44 @@
+name: Node Benchmark
+
+on:
+  pull_request:
+
+jobs:
+  run-benchmark:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Node benchmark
+        id: benchmark # Give this step an id to access its output later
+        run: npm run node-bench
+
+      - name: Comment benchmark output on PR
+        uses: actions/github-script@v7
+        if: github.event_name == 'pull_request' # Only run on PRs
+        with:
+          script: |
+            const output = `${{ steps.benchmark.outputs.stdout }}`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Node.js Benchmark Results  бенчмарк :rocket:
+
+\`\`\`
+${output}
+\`\`\`
+`
+            });

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,16 +29,21 @@ jobs:
         uses: actions/github-script@v7
         if: github.event_name == 'pull_request' # Only run on PRs
         with:
+          github-token: ${{secrets.GITHUB_TOKEN}} # Explicitly pass the token
           script: |
-            const output = `${{ steps.benchmark.outputs.stdout }}`;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `## Node.js Benchmark Results  бенчмарк :rocket:
+            const rawOutput = `${{ steps.benchmark.outputs.stdout }}`;
+            // Further escape backticks for the final markdown code block
+            const output = rawOutput.replace(/`/g, '\\`');
+
+            const body = `## Node.js Benchmark Results бенчмарк :rocket:
 
 \`\`\`
 ${output}
 \`\`\`
-`
+`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
             });

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,7 +24,10 @@ jobs:
 
       - name: Run Node benchmark
         id: benchmark # Give this step an id to access its output later
-        run: npm run node-bench
+        run: |
+          echo "stdout<<EOF" >> $GITHUB_OUTPUT
+          npm run node-bench >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Comment benchmark output on PR
         uses: actions/github-script@v7

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,13 +34,9 @@ jobs:
             const rawOutput = `${{ steps.benchmark.outputs.stdout }}`;
             // Further escape backticks for the final markdown code block
             const output = rawOutput.replace(/`/g, '\\`');
+            const backticks = '```';
+            const body = '## Benchmark Results :rocket:\n\n' + backticks + output + backticks;
 
-            const body = `## Node.js Benchmark Results бенчмарк :rocket:
-
-\`\`\`
-${output}
-\`\`\`
-`;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow in `.github/workflows/benchmark.yml`.

The workflow is triggered on `pull_request` events and performs the following:
1. Checks out the repository.
2. Sets up Node.js version 22.
3. Installs npm dependencies using `npm ci`.
4. Runs the Node.js benchmark suite using `npm run node-bench`.
5. Posts the stdout of the benchmark command as a comment on the triggering pull request.

This will help you track the performance impact of changes directly within the PR review process.