### PR TITLE
Improve tokenizer speed with optimized search

### DIFF
--- a/src/test/tokenize_test.ts
+++ b/src/test/tokenize_test.ts
@@ -118,6 +118,15 @@ suite('tokenizeJsonStream', () => {
       {type: JsonTokenType.StringEnd, value: undefined},
     ]);
   });
+  test('handles escape split across chunks', async () => {
+    const tokens = tokenize(makeStream('"a\\', 'n"'));
+    assert.deepEqual(await toFlatArray(tokens), [
+      {type: JsonTokenType.StringStart, value: undefined},
+      {type: JsonTokenType.StringMiddle, value: 'a'},
+      {type: JsonTokenType.StringMiddle, value: '\n'},
+      {type: JsonTokenType.StringEnd, value: undefined},
+    ]);
+  });
   test('can tokenize an empty object', async () => {
     const tokens = tokenize(makeStream('{}'));
     assert.deepEqual(await toFlatArray(tokens), [

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -613,17 +613,22 @@ class Input {
    */
   takeUntilQuoteOrBackslash(): [string, boolean] {
     const buf = this.buffer;
-    let i = 0;
-    while (i < buf.length) {
-      const c = buf.charCodeAt(i);
-      if (c === 34 || c === 92) {
-        const result = buf.slice(0, i);
-        this.buffer = buf.slice(i);
-        return [result, true];
-      }
-      i++;
+    const quoteIndex = buf.indexOf('"');
+    const backslashIndex = buf.indexOf('\\');
+    let firstIndex: number;
+    if (quoteIndex === -1) {
+      firstIndex = backslashIndex;
+    } else if (backslashIndex === -1) {
+      firstIndex = quoteIndex;
+    } else {
+      firstIndex = quoteIndex < backslashIndex ? quoteIndex : backslashIndex;
     }
-    this.buffer = '';
-    return [buf, false];
+    if (firstIndex === -1) {
+      this.buffer = '';
+      return [buf, false];
+    }
+    const result = buf.slice(0, firstIndex);
+    this.buffer = buf.slice(firstIndex);
+    return [result, true];
   }
 }


### PR DESCRIPTION
## Summary
- search string for quote or backslash using `indexOf`
- add a regression test for escape sequences split across chunks

## Testing
- `npm test`