### PR TITLE
Add property based testing, fix __proto__ key bug.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@typescript-eslint/parser": "^7.0.1",
         "esbuild": "^0.25.4",
         "eslint": "^8.48.0",
+        "fast-check": "^4.3.0",
         "np": "^10.0.7",
         "prettier": "^3.3.3",
         "tachometer": "^0.7.1",
@@ -3308,6 +3309,28 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.3.0.tgz",
+      "integrity": "sha512-JVw/DJSxVKl8uhCb7GrwanT9VWsCIdBkK3WpP37B/Au4pyaspriSjtrY2ApbSFwTg3ViPfniT13n75PhzE7VEQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -7087,6 +7110,22 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
     },
     "node_modules/qs": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@typescript-eslint/parser": "^7.0.1",
     "esbuild": "^0.25.4",
     "eslint": "^8.48.0",
+    "fast-check": "^4.3.0",
     "np": "^10.0.7",
     "prettier": "^3.3.3",
     "tachometer": "^0.7.1",

--- a/src/test/property_based_test.ts
+++ b/src/test/property_based_test.ts
@@ -1,0 +1,232 @@
+/**
+ * @license
+ * Copyright Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as assert from 'node:assert/strict';
+import {suite, test} from 'node:test';
+import {parse} from '../index.js';
+import {assertSameAsJsonParse, makeStreamOfChunks, toArray} from './utils.js';
+import fc from 'fast-check';
+
+async function* mapStructuralClone<T>(
+  iter: AsyncIterable<T>,
+): AsyncIterableIterator<T> {
+  for await (const val of iter) {
+    yield structuredClone(val);
+  }
+}
+
+// If run with TEST_HARDER or if running in CI, run more tests than usual.
+const shouldTestHarder = !!process.env['TEST_HARDER'] || !!process.env['CI'];
+
+if (shouldTestHarder) {
+  const numRuns = fc.readConfigureGlobal().numRuns ?? 100;
+  fc.configureGlobal({numRuns: numRuns * 100});
+}
+
+suite('property based tests', () => {
+  test('valid json parses same as JSON.parse', async () => {
+    return fc.assert(
+      fc.asyncProperty(fc.json(), async (json) => {
+        await assertSameAsJsonParse(json, JSON.stringify(json), true);
+        return true;
+      }),
+    );
+  });
+
+  test('arbitrary strings parse the same', async () => {
+    return fc.assert(
+      fc.asyncProperty(fc.string(), async (json) => {
+        await assertSameAsJsonParse(json, JSON.stringify(json), undefined);
+        return true;
+      }),
+    );
+  });
+
+  const {jsonValue} = fc.letrec((tie) => {
+    return {
+      jsonValue: fc.oneof(
+        fc.constant(null),
+        fc.boolean(),
+        fc.string(),
+        fc.double(),
+        tie('jsonArray'),
+        tie('jsonObject'),
+      ),
+      jsonArray: fc.array(tie('jsonValue')),
+      jsonObject: fc.dictionary(fc.string(), tie('jsonValue')),
+    };
+  });
+
+  function incrementalValues(value: unknown): unknown[] {
+    if (
+      typeof value === 'number' ||
+      typeof value === 'boolean' ||
+      value === null
+    ) {
+      return [value];
+    }
+    if (typeof value === 'string') {
+      const result = [];
+      for (let i = 0; i <= value.length; i++) {
+        result.push(value.slice(0, i));
+      }
+      return result;
+    }
+    if (Array.isArray(value)) {
+      const valueArr: unknown[] = value;
+      const result: Array<unknown[]> = [[]];
+      for (let i = 0; i < value.length; i++) {
+        const itemValues = incrementalValues(value[i]);
+        for (let j = 0; j < itemValues.length; j++) {
+          result.push([...valueArr.slice(0, i), itemValues[j]]);
+        }
+      }
+      return result;
+    }
+    if (typeof value !== 'object' || value === null) {
+      throw new Error(`Unexpected value type: ${typeof value}`);
+    }
+    // we have an object
+    const result: Array<object> = [{}];
+    let baseObj: object = {};
+    for (const [key, val] of Object.entries(value)) {
+      const itemValues = incrementalValues(val);
+      for (let j = 0; j < itemValues.length; j++) {
+        result.push({...baseObj, [key]: itemValues[j]});
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      baseObj = {...baseObj, [key]: val};
+    }
+    return result;
+  }
+
+  test('we get incremental values as expected', async () => {
+    return fc.assert(
+      fc.asyncProperty(jsonValue, async (value: unknown) => {
+        const jsonString = JSON.stringify(value);
+        const expectedIncrementalValues: unknown[] = incrementalValues(
+          JSON.parse(jsonString),
+        );
+
+        const stringStream = makeStreamOfChunks(jsonString, 1);
+        const partialValues = await toArray(
+          mapStructuralClone(parse(stringStream)),
+        );
+        assert.deepEqual(partialValues, expectedIncrementalValues);
+        return true;
+      }),
+    );
+  });
+
+  test('strings only grow', async () => {
+    // check the invariant
+    function check(prev: unknown, curr: unknown) {
+      if (typeof prev === 'string') {
+        assert.ok(typeof curr === 'string');
+        assert.ok(curr.length >= prev.length);
+        assert.ok(curr.startsWith(prev));
+      } else if (Array.isArray(prev)) {
+        assert.ok(Array.isArray(curr));
+        for (let i = 0; i < prev.length - 1; i++) {
+          assert.deepEqual(curr[i], prev[i]);
+        }
+        if (prev.length > 0 && curr.length > 0) {
+          check(prev[prev.length - 1], curr[prev.length - 1]);
+        }
+      } else if (typeof prev === 'object' && prev !== null) {
+        assert.ok(typeof curr === 'object');
+        assert.ok(curr !== null);
+        const pKeys = Object.keys(prev);
+        const nKeys = Object.keys(curr);
+        for (let i = 0; i < pKeys.length - 1; i++) {
+          const key = pKeys[i]!;
+          assert.ok(Object.hasOwn(curr, key));
+          assert.deepEqual(
+            (curr as {[key: string]: unknown})[key],
+            (prev as {[key: string]: unknown})[key],
+          );
+        }
+        if (pKeys.length > 0 && nKeys.length > 0) {
+          const lastPKey = pKeys[pKeys.length - 1]!;
+          if (Object.hasOwn(curr, lastPKey)) {
+            check(
+              (prev as {[key: string]: unknown})[lastPKey],
+              (curr as {[key: string]: unknown})[lastPKey],
+            );
+          }
+        }
+      }
+    }
+
+    return fc.assert(
+      fc.asyncProperty(jsonValue, async (value: unknown) => {
+        const jsonString = JSON.stringify(value);
+        const stringStream = makeStreamOfChunks(jsonString, 1);
+        let previous: unknown = undefined;
+        for await (const next of parse(stringStream)) {
+          if (previous === undefined) {
+            previous = structuredClone(next);
+            continue;
+          }
+          check(previous, next);
+          previous = structuredClone(next);
+        }
+      }),
+    );
+  });
+
+  test('atomic values are atomic', async () => {
+    return fc.assert(
+      fc.asyncProperty(
+        fc.oneof(fc.constant(null), fc.boolean(), fc.double()),
+        async (value: unknown) => {
+          const jsonString = JSON.stringify(value);
+          const stringStream = makeStreamOfChunks(jsonString, 1);
+          const partialValues = await toArray(
+            mapStructuralClone(parse(stringStream)),
+          );
+          assert.deepEqual(partialValues, [JSON.parse(JSON.stringify(value))]);
+        },
+      ),
+    );
+  });
+
+  test('objects with arbitrary keys', async () => {
+    const keyValuePairs = fc.array(fc.tuple(fc.string(), jsonValue));
+    return fc.assert(
+      fc.asyncProperty(keyValuePairs, async (entries) => {
+        const jsonString =
+          '{' +
+          entries
+            .map(([k, v]) => `${JSON.stringify(k)}:${JSON.stringify(v)}`)
+            .join(',') +
+          '}';
+        await assertSameAsJsonParse('Randomly', jsonString, undefined);
+      }),
+    );
+  });
+
+  test('duplicate keys behave like JSON.parse', async () => {
+    const keyValuePairs = fc.array(fc.tuple(fc.string(), jsonValue), {
+      minLength: 1,
+    });
+    return fc.assert(
+      fc.asyncProperty(keyValuePairs, async (entries) => {
+        const jsonString =
+          '{' +
+          [...entries, ...entries]
+            .map(([k, v]) => `${JSON.stringify(k)}:${JSON.stringify(v)}`)
+            .join(',') +
+          '}';
+        await assertSameAsJsonParse(
+          'Randomly generated',
+          jsonString,
+          undefined,
+        );
+      }),
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es2022",
     "module": "ES2020",
+    "moduleResolution": "node",
     "sourceMap": true,
     "rootDir": "./src",
     "outDir": "./dist",


### PR DESCRIPTION
Using fast-check to do property based testing of jsonriver, to enforce
our invariants.

Found a bug where we don't match the behavior of JSON.parse for the
document `{"__proto__": 1}`